### PR TITLE
Revert target static for nuxt

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -5,7 +5,6 @@ const SITE_DESCRIPTION =
   "A community database to share clinic information in Japan.";
 
 export default {
-  target: "static",
   // Global page headers: https://go.nuxtjs.dev/config-head
   head: {
     titleTemplate: "COVID-19 Vaccination Info",


### PR DESCRIPTION
This negatively impacts the loading state layout on slow devices on desktop. We can revert this until we apply some styles to stabilize the layout shifts.

This hurts our performance pretty significantly. I actually don't think the UX degradation is that bad (mobile is OK, and desktop users are more likely to have a faster connection). 

Basically, my preference here would be to fix forward rather than revert this change. However, this is not my project, so I'm opening this PR.

<img width="485" alt="image" src="https://user-images.githubusercontent.com/8826860/122500077-0ae7c800-d02d-11eb-9324-4fa26cd8a003.png">
