### PR TITLE
Unfix absolute positioning for toolbar to allow for scroll on mobile.…

### DIFF
--- a/components/Toolbar.vue
+++ b/components/Toolbar.vue
@@ -17,7 +17,6 @@
     <v-navigation-drawer
       color="#031525"
       v-model="drawer"
-      absolute
       temporary
       dark
       app


### PR DESCRIPTION
… Resolves #52.

## Resolves #52 

### How to test

1. Build and start
2. Set browser to mobile emulation mode from dev console
3. Scroll to bottom of page, such that top bar is out of view
4. Click on the hamburger icon to show the menu

At 4) with this change, the menu will show as desired, and without, the user will only see the overlay, but no menu items.

### Screenshots

<img width="422" alt="スクリーンショット 2021-06-19 14 43 05" src="https://user-images.githubusercontent.com/6155643/122632218-63da5d80-d10c-11eb-8d95-0143fa4aa176.png">

