### PR TITLE
add admin link to toolbar when logged in

### DIFF
--- a/components/Toolbar.vue
+++ b/components/Toolbar.vue
@@ -82,13 +82,12 @@ export default {
         { title: "Home", icon: "mdi-home-city", route: "index" },
         this.$store.getters.isUserLoggedIn
           ? [
-              { title: "Logout", icon: "mdi-account", route: "logout" },
-
               {
                 title: "Admin Dashboard",
                 icon: "mdi-shield-account-variant",
                 route: "admin-pending",
               },
+              { title: "Logout", icon: "mdi-account", route: "logout" },
             ]
           : { title: "Login", icon: "mdi-account", route: "login" },
         { title: "About", icon: "mdi-head-question", route: "about" },

--- a/components/Toolbar.vue
+++ b/components/Toolbar.vue
@@ -14,13 +14,7 @@
         }}</v-btn>
       </nuxt-link>
     </v-app-bar>
-    <v-navigation-drawer
-      color="#031525"
-      v-model="drawer"
-      temporary
-      dark
-      app
-    >
+    <v-navigation-drawer color="#031525" v-model="drawer" temporary dark app>
       <v-list dense>
         <v-list-item
           v-for="item in items"
@@ -87,10 +81,18 @@ export default {
       return [
         { title: "Home", icon: "mdi-home-city", route: "index" },
         this.$store.getters.isUserLoggedIn
-          ? { title: "Logout", icon: "mdi-account", route: "logout" }
+          ? [
+              { title: "Logout", icon: "mdi-account", route: "logout" },
+
+              {
+                title: "Admin Dashboard",
+                icon: "mdi-shield-account-variant",
+                route: "admin-pending",
+              },
+            ]
           : { title: "Login", icon: "mdi-account", route: "login" },
         { title: "About", icon: "mdi-head-question", route: "about" },
-      ];
+      ].flat();
     },
   },
   methods: {},


### PR DESCRIPTION
## Resolves #77 

I'm not super familiar with Vue and wanted to start with something simple, so here's a quick fix to the toolbar that adds a link pointing to the admin dashboard when you're logged in.

### How to test

You should be able to check if you log in as admin and click the toolbar expander.

### Screenshots

I checked the readme, but I couldn't find any instructions on how to try logging into admin locally without a working Firebase API key; probably unnecessary, but it might be helpful to be able to mock the API calls. Please take this PR as submission for permission to help develop 🙇🏻 

Here's a screenshot of the button setup to only work when you're logged out, though:

![image](https://user-images.githubusercontent.com/1944082/122764610-9a65d300-d2da-11eb-80bf-2ebe1b968fcf.png)

If there's a preference for another icon then I can switch it out. I just went with something that looked admin-ey 🤔 

(as an aside, it seems the only indication that you failed login is in the console, which is probably good enough but it'd be nice if there was an alert of some kind)

Also, today I learned that the array flattening method in vanilla JS is just called `flat()`.
