### PR TITLE
fixed twitter link interpolation

### DIFF
--- a/pages/about.vue
+++ b/pages/about.vue
@@ -14,10 +14,11 @@
       </div>
       <div>
         <h2>{{ $t("about.creatorQ") }}</h2>
-        {{ $t("about.creatorA")
-        }}<a href="https://twitter.com/theyokohamalife" target="_blank"
-          >@theyokohamalife</a
-        >
+        <i18n path="about.creatorA" tag="span">
+          <a href="https://twitter.com/theyokohamalife" target="_blank"
+            >@theyokohamalife</a
+          >
+        </i18n>
       </div>
       <div>
         <h2>{{ $t("about.supportQ") }}</h2>


### PR DESCRIPTION
## Resolves #104 

Another quick fix! As suggested by @ann-kilzer, I moved the link into an `i18n` component, which fixed the interpolation.

### How to test

Check the about page (locally: http://localhost:3000/about)

### Screenshots

![image](https://user-images.githubusercontent.com/1944082/122908142-c773bd80-d38e-11eb-9939-d9240887846a.png)
