### PR TITLE
Change the i18n key for the flag

### DIFF
--- a/components/CancellationList.vue
+++ b/components/CancellationList.vue
@@ -142,7 +142,7 @@ export default {
         sortable: false,
       },
       {
-        text: `${vue.$t("cancelList.header.flag")}:`,
+        text: `${vue.$t("cancelList.header.report")}:`,
         value: "flag",
         sortable: false,
       },


### PR DESCRIPTION
The i18n English key has been change to "report", but the frontend doesn't reflect this change

### Screenshots
Before : 
![image](https://user-images.githubusercontent.com/35844978/123002687-30a00480-d380-11eb-802f-b911b52b37ec.png)

After : 
![image](https://user-images.githubusercontent.com/35844978/123002808-53cab400-d380-11eb-87ca-e2090783a4dd.png)

