### PR TITLE
Improve lint-staged config

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -17,23 +17,23 @@ diverse, inclusive, and healthy community.
 Examples of behavior that contributes to a positive environment for our
 community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the
+- Focusing on what is best not just for us as individuals, but for the
   overall community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or
+- The use of sexualized language or imagery, and sexual attention or
   advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
   address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Enforcement Responsibilities
@@ -106,7 +106,7 @@ Violating these terms may lead to a permanent ban.
 ### 4. Permanent Ban
 
 **Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
+standards, including sustained inappropriate behavior, harassment of an
 individual, or aggression toward or disparagement of classes of individuals.
 
 **Consequence**: A permanent ban from any sort of public interaction within

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,5 @@
 Welcome to Findadoc Japan! We're grateful for our volunteers 😊
 
-
 # Where should I start?
 
 👉️ Join the [Slack](https://join.slack.com/t/find-a-doc/shared_invite/zt-s4744a6o-MGaGHzLN5wB9aXeha3vdsQ) 💬
@@ -10,16 +9,17 @@ Welcome to Findadoc Japan! We're grateful for our volunteers 😊
 1. Fork the repo and build the source by following the [README](https://github.com/ourjapanlife/findadoc-frontend#readme)
 2. Find a good issue by checking out the [latest Project Board](https://github.com/ourjapanlife/findadoc-frontend/projects/2), or looking for something tagged "Good First Issue"
 3. Submit a PR and work with the team to merge it
-🙌🏻
+   🙌🏻
 
 👉️ Translators 🌐
+
 1. [Visit the Localization Subproject](https://github.com/ourjapanlife/findadoc-localization) for further instructions
 
-
 👉️ UI/UX Designers (and people interested in developing new features) ✨
+
 1. Check out the Wiki](https://github.com/ourjapanlife/findadoc-frontend/wiki) to learn about User stories, etc.
-2. Join the  #new-features Slack Channel
-🎨
+2. Join the #new-features Slack Channel
+   🎨
 
 ## What if I get stuck?
 
@@ -28,21 +28,22 @@ Welcome to Findadoc Japan! We're grateful for our volunteers 😊
 - Everyone: Ask in Slack
 
 ## Helpful Info
-  
- ### Related Technologies
- - [Vue](https://vuejs.org/) A JavaScript framework
- - [Nuxt.js](https://nuxtjs.org/) A Vue framework
- - [vue-18n](https://kazupon.github.io/vue-i18n/) - internationalization
- - [nuxt/i18n](https://i18n.nuxtjs.org/) - nuxt wrapper for vue-i18n
- - [Vuetify 1.5](https://v15.vuetifyjs.com/) - Material Design Framework
- - [Material Design](https://material.io/design) - A design framework created by Google based on the concept of layered paper
- - [Firebase](https://firebase.google.com/) - A platform for web applications. Hosts the data store
+
+### Related Technologies
+
+- [Vue](https://vuejs.org/) A JavaScript framework
+- [Nuxt.js](https://nuxtjs.org/) A Vue framework
+- [vue-18n](https://kazupon.github.io/vue-i18n/) - internationalization
+- [nuxt/i18n](https://i18n.nuxtjs.org/) - nuxt wrapper for vue-i18n
+- [Vuetify 1.5](https://v15.vuetifyjs.com/) - Material Design Framework
+- [Material Design](https://material.io/design) - A design framework created by Google based on the concept of layered paper
+- [Firebase](https://firebase.google.com/) - A platform for web applications. Hosts the data store
 
 ### Code Style
+
 - ESLint
 - Prettier
 
 ### Glossary
 
 **i18n**: internationalization (because there are 18 letters)
-

--- a/README.md
+++ b/README.md
@@ -25,9 +25,11 @@ $ git submodule update
 If you have more issues with submodules, please check out [TROUBLESHOOTING.md](https://github.com/ourjapanlife/findadoc-frontend/blob/main/TROUBLESHOOTING.md)
 
 ## Environment Setup
+
 ```bash
 $ cp .env.sample .env
 ```
+
 Get the Firebase API key from the project leads and edit the `.env` file to have this value.
 
 ## Build Setup
@@ -56,7 +58,7 @@ Under the hood, this project uses [nuxt/i18n](https://i18n.nuxtjs.org/) and [vue
 The locale files are managed through a separate repo, incorporated as a submodule. Here is the process for adding new translation keys:
 
 1. Clone the [findadoc-localization repo](https://github.com/ourjapanlife/findadoc-localization)
-2. Edit the `locales/en.json` to contain the new keys. 
+2. Edit the `locales/en.json` to contain the new keys.
 3. If you know another language, feel free to add the same key and translation to the appropriate locale file. Omit if you don't know it; we use English as the [fallback language](https://kazupon.github.io/vue-i18n/guide/fallback.html) so nothing will break.
 4. Make a pull request to the localization repo and wait for it to be merged to `main`
 5. Update the submodule (see above) to get the latest keys

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,9 +1,8 @@
 # Troubleshooting :sob: :sob: :sob: => 😊 :blush: 😊
 
-
 ## Submodule Troubleshooting
 
-In general we do not update the submodule outside of the workflow described on the README page. 
+In general we do not update the submodule outside of the workflow described on the README page.
 Here are some tips on how to get out of an accidental commit or submodule update.
 
 There is also lots of documentation here: https://git-scm.com/book/en/v2/Git-Tools-Submodules
@@ -43,10 +42,12 @@ If the changes to the i18n folder no longer show up in status, you are good 👍
 #### I haven't pushed yet
 
 1. Revert the commit
+
 ```sh
 git reset HEAD~
 git stash
 ```
+
 2. Follow the steps from [the previous item](#There-are-i18n-changes-locally-but-I-don't-want-to-commit-them)
 
 #### I pushed the changes upstream
@@ -75,5 +76,3 @@ git diff main
 git push
 
 ```
-
-

--- a/components/CancellationList.vue
+++ b/components/CancellationList.vue
@@ -44,7 +44,9 @@
     </v-data-table>
     <v-dialog v-model="showDialog.report" max-width="600px">
       <v-card>
-        <v-card-title class="text-h5">{{ $t("cancelList.report.title") }}</v-card-title>
+        <v-card-title class="text-h5">{{
+          $t("cancelList.report.title")
+        }}</v-card-title>
         <v-form v-model="validReport" ref="form" lazy-validation>
           <span
             ><b>{{ $t("cancelList.report.clinicName") }}</b>

--- a/components/Toolbar.vue
+++ b/components/Toolbar.vue
@@ -63,7 +63,11 @@ export default {
   computed: {
     items() {
       return [
-        { title: this.$t("toolbar.home"), icon: "mdi-home-city", route: "index" },
+        {
+          title: this.$t("toolbar.home"),
+          icon: "mdi-home-city",
+          route: "index",
+        },
         this.$store.getters.isUserLoggedIn
           ? [
               {
@@ -71,10 +75,22 @@ export default {
                 icon: "mdi-shield-account-variant",
                 route: "admin-pending",
               },
-              { title: this.$t("toolbar.logout"), icon: "mdi-account", route: "logout" },
+              {
+                title: this.$t("toolbar.logout"),
+                icon: "mdi-account",
+                route: "logout",
+              },
             ]
-          : { title: this.$t("toolbar.login"), icon: "mdi-account", route: "login" },
-        { title: this.$t("toolbar.about"), icon: "mdi-head-question", route: "about" },
+          : {
+              title: this.$t("toolbar.login"),
+              icon: "mdi-account",
+              route: "login",
+            },
+        {
+          title: this.$t("toolbar.about"),
+          icon: "mdi-head-question",
+          route: "about",
+        },
       ].flat();
     },
   },

--- a/package.json
+++ b/package.json
@@ -29,12 +29,11 @@
     "prettier": "2.3.1"
   },
   "lint-staged": {
-    "*.js,*.vue": [
-      "eslint",
-      "prettier --write"
+    "**/*.{js,vue,json}": [
+      "eslint --fix"
     ],
-    ".json": [
-      "eslint"
+    "**/*.{js,vue,json,css,md}": [
+      "prettier --write"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "lint-staged": {
     "**/*.{js,vue,json}": [
-      "eslint --fix"
+      "eslint"
     ],
     "**/*.{js,vue,json,css,md}": [
       "prettier --write"


### PR DESCRIPTION
## Part of #44 

I'd noticed that lint-stage wasn't configured well and lots of un-prettier-ed code was getting into `main`. 

- run `eslint`, `prettier --write` on all staged changes
- Include CSS and Markdown files
- fix up all files with the updated rules