### PR TITLE
add prescreening doc alert

### DIFF
--- a/components/AlertsList.vue
+++ b/components/AlertsList.vue
@@ -6,10 +6,25 @@
     >
       {{ $t("index.massSite") }}
     </alert>
+    <alert
+      :buttonText="$t('index.getDocument')"
+      buttonUrl="https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/vaccine_tagengo.html"
+    >
+      {{ $t("index.prevaccinationScreening") }}
+    </alert>
   </v-container>
 </template>
 <style>
 .alerts-list {
   margin: 0.5em 0 2em 0;
+}
+
+@media only screen and (max-width: 600px) {
+  .alerts-list {
+    margin: 0px;
+  }
+  .container {
+    padding-bottom: 8px;
+  }
 }
 </style>

--- a/components/AlertsList.vue
+++ b/components/AlertsList.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container class="alerts-list">
+  <v-container class="pb-sm-0 ma-sm-0">
     <alert
       :buttonText="$t('index.register')"
       buttonUrl="https://www.mod.go.jp/j/approach/defense/saigai/2020/covid/center.html"
@@ -14,17 +14,3 @@
     </alert>
   </v-container>
 </template>
-<style>
-.alerts-list {
-  margin: 0.5em 0 2em 0;
-}
-
-@media only screen and (max-width: 600px) {
-  .alerts-list {
-    margin: 0px;
-  }
-  .container {
-    padding-bottom: 8px;
-  }
-}
-</style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container>
     <div align="center">
-      <h1 id="page-title">{{ $t("index.title") }}</h1>
+      <h1 class="mt-md-10 mb-md-5" id="page-title">{{ $t("index.title") }}</h1>
     </div>
     <alerts-list />
     <div>
@@ -9,13 +9,3 @@
     </div>
   </v-container>
 </template>
-<style scoped>
-#page-title {
-  margin: 1em 0 1em 0;
-}
-@media only screen and (max-width: 600px) {
-  #page-title {
-    margin: 0px;
-  }
-}
-</style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -13,4 +13,9 @@
 #page-title {
   margin: 1em 0 1em 0;
 }
+@media only screen and (max-width: 600px) {
+  #page-title {
+    margin: 0px;
+  }
+}
 </style>


### PR DESCRIPTION
1. Adds a link to the required prevaccine screening document and translations.
2. Reduces padding on mobile to reduce empty space when alerts are dismissed.


### Screenshots
![Screen Shot 2021-06-24 at 9 35 15 PM (2)](https://user-images.githubusercontent.com/31802656/123263617-27579900-d534-11eb-8fc1-fdcf4c771ff4.png)


