### PR TITLE
Adjust material color variables

### DIFF
--- a/assets/variables.scss
+++ b/assets/variables.scss
@@ -2,3 +2,7 @@
 //
 // The variables you want to modify
 // $font-size-root: 20px;
+
+.black-text {
+  color: black !important;
+}

--- a/components/ActiveClinicData.vue
+++ b/components/ActiveClinicData.vue
@@ -42,17 +42,13 @@
             <v-card-actions>
               <v-spacer></v-spacer>
               <v-btn
-                color="blue darken-1"
+                color="primary"
                 text
                 @click="handleApproveBtnPressed(item)"
               >
                 Approve
               </v-btn>
-              <v-btn
-                color="blue darken-1"
-                text
-                @click="handleCancelEditBtnPressed"
-              >
+              <v-btn color="primary" text @click="handleCancelEditBtnPressed">
                 Cancel
               </v-btn>
             </v-card-actions>

--- a/components/Alert.vue
+++ b/components/Alert.vue
@@ -1,18 +1,14 @@
 <template>
   <v-container>
-    <v-alert dismissible color="cyan" text outlined>
+    <v-alert dismissible color="alertCard">
       <v-row align="center">
         <v-col class="grow">
           <slot></slot>
         </v-col>
         <v-col class="shrink">
-          <v-btn
-            light
-            color="cyan lighten-1"
-            :href="buttonUrl"
-            target="_blank"
-            >{{ buttonText }}</v-btn
-          >
+          <v-btn light color="alertButton" :href="buttonUrl" target="_blank">{{
+            buttonText
+          }}</v-btn>
         </v-col>
       </v-row>
     </v-alert>

--- a/components/CancellationList.vue
+++ b/components/CancellationList.vue
@@ -56,7 +56,7 @@
             v-model="report.message"
             :rules="reportRules"
             required
-            background-color="light-blue lighten-4"
+            background-color="light-blue lighten-5"
             color="black"
             :label="$t('cancelList.report.reason')"
           ></v-textarea>

--- a/components/CancellationList.vue
+++ b/components/CancellationList.vue
@@ -63,14 +63,13 @@
           <v-card-actions>
             <v-spacer></v-spacer>
             <v-btn
-              color="primary"
               :disabled="!validReport || report.message.length < 5"
               text
               @click="sendReport"
             >
               {{ $t("cancelList.report.submitReport") }}
             </v-btn>
-            <v-btn color="secondary" text @click="cancelReport">
+            <v-btn text @click="cancelReport">
               {{ $t("general.cancel") }}
             </v-btn>
           </v-card-actions>

--- a/components/DeleteDialog.vue
+++ b/components/DeleteDialog.vue
@@ -6,10 +6,10 @@
       >
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn color="blue darken-1" text @click="handleCancelBtnPressed">{{
+        <v-btn color="primary" text @click="handleCancelBtnPressed">{{
           $t("general.cancel")
         }}</v-btn>
-        <v-btn color="blue darken-1" text @click="handleConfirmBtnPressed">{{
+        <v-btn color="primary" text @click="handleConfirmBtnPressed">{{
           $t("general.delete")
         }}</v-btn>
         <v-spacer></v-spacer>

--- a/components/PendingSubmissions.vue
+++ b/components/PendingSubmissions.vue
@@ -44,17 +44,13 @@
             <v-card-actions>
               <v-spacer></v-spacer>
               <v-btn
-                color="blue darken-1"
+                color="primary"
                 text
                 @click="handleApproveBtnPressed(item)"
               >
                 {{ $t("general.approve") }}
               </v-btn>
-              <v-btn
-                color="blue darken-1"
-                text
-                @click="handleCancelEditBtnPressed"
-              >
+              <v-btn color="primary" text @click="handleCancelEditBtnPressed">
                 {{ $t("general.cancel") }}
               </v-btn>
             </v-card-actions>

--- a/components/SiteFooter.vue
+++ b/components/SiteFooter.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-footer fixed app dark color="footer">
+  <v-footer fixed app dark color="secondary">
     <v-col>
       <v-row>
         <v-col id="donate">

--- a/components/Toolbar.vue
+++ b/components/Toolbar.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <v-app-bar dense light app>
+    <v-app-bar dense app id="topbar">
       <v-app-bar-nav-icon @click.stop="drawer = !drawer"></v-app-bar-nav-icon>
       <v-toolbar-title>
         <!-- Set a mobile breakpoint for the name? -->
@@ -10,12 +10,20 @@
       >
       <v-spacer></v-spacer>
       <nuxt-link :to="localePath({ name: 'add-clinic' })">
-        <v-btn light color="cyan lighten-3">{{
+        <v-btn color="accent" class="black--text">{{
           $t("toolbar.addClinic")
         }}</v-btn>
       </nuxt-link>
     </v-app-bar>
-    <v-navigation-drawer color="#031525" v-model="drawer" temporary dark app>
+
+    <v-navigation-drawer
+      color="primary"
+      v-model="drawer"
+      temporary
+      dark
+      app
+      id="sidebar"
+    >
       <v-list dense>
         <v-list-item
           v-for="item in items"

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app dark>
+  <v-app>
     <h1 v-if="error.statusCode === 404">
       {{ $t("error.notFound") }}
     </h1>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -139,24 +139,32 @@ export default {
       light: true,
       themes: {
         dark: {
-          primary: colors.blue.darken2,
-          accent: colors.grey.darken3,
-          secondary: colors.amber.darken2,
+          // material trio
+          primary: "#031525",
+          accent: colors.cyan.lighten1,
+          secondary: colors.indigo.darken2,
+          // alert colors
           info: colors.teal.lighten1,
           warning: colors.amber.base,
           error: colors.deepOrange.accent4,
           success: colors.green.accent3,
+          // misc
+          alertCard: colors.cyan.lighten4,
+          alertButton: colors.cyan.lighten1,
         },
         light: {
-          primary: colors.blue.darken2,
-          accent: colors.grey.darken3,
-          secondary: colors.amber.darken3,
-          info: colors.teal.lighten1,
-          warning: colors.amber.base,
-          error: colors.deepOrange.accent4,
-          success: colors.green.accent3,
-          toolbar: colors.indigo.lighten1,
-          footer: colors.indigo.darken2,
+          // material trio
+          primary: "#031525",
+          accent: colors.cyan.lighten3,
+          secondary: colors.indigo.darken2,
+          // alert colors
+          info: colors.teal.darken2,
+          warning: colors.orange.darken4,
+          error: colors.red.darken4,
+          success: colors.green.darken3,
+          // misc
+          alertCard: colors.cyan.lighten4,
+          alertButton: colors.cyan.lighten1,
         },
       },
     },

--- a/pages/add-clinic.vue
+++ b/pages/add-clinic.vue
@@ -10,7 +10,7 @@
         <h2>{{ $t("add-clinic.fillForm") }}</h2>
       </div>
       <v-container>
-        <div align="center" class="romaji">
+        <div align="center" class="red--text text--darken-4">
           <b>{{ $t("add-clinic.romajiOnly") }}</b>
         </div>
         <v-row>
@@ -71,8 +71,8 @@
       </div>
       <div align="center">
         <v-btn
-          dark
-          color="blue darken-1"
+          color="accent"
+          class="black--text"
           :disabled="!valid"
           @click="submitData"
         >
@@ -149,9 +149,6 @@ export default {
 </script>
 
 <style scoped>
-.romaji {
-  color: red;
-}
 .v-btn {
   margin-top: 20px !important;
   margin-bottom: 20px !important;


### PR DESCRIPTION
## Resolves #14 and a lot of the work for #11 

There's a lot of changes in here relating to how we use Material colors and the Vuetify variables.  *I tried to mostly leave colors as-is, or keep things in the same color family.* 

The exceptions are 
1 ) readability (meet WCAG AA as much as possible)
2 ) consistency (most of our buttons are the cyan, so I went with that)


- We weren't taking advantage of the "primary" "secondary" "accent" values previously, so I updated those values to reflect the main colors I saw in the current design.
- I removed some variables that defined redundant or unused colors
- I adjusted the info/success/error/warning colors so they would meet AA contrast when used as text against a white background
- Removed some CSS text coloring in favor of the built-in Vuetify text color classes





### How to test

Look through the site and verify that things look good


### Screenshots

Before:

The error color against the blue created a lot of eye strain
<img width="583" alt="COVID-19_Vaccination_Info" src="https://user-images.githubusercontent.com/4602369/123284101-f339a380-d546-11eb-9609-82054249514b.png">

The cyan color is beautiful, but too low contrast as text against a colored background:

<img width="1211" alt="COVID-19_Vaccination_Info" src="https://user-images.githubusercontent.com/4602369/123284415-3431b800-d547-11eb-8ab8-edf1357e3b8b.png">

After: 


[ one moment, updating]
