### PR TITLE
Toolbar active links styles

### DIFF
--- a/components/Toolbar.vue
+++ b/components/Toolbar.vue
@@ -30,6 +30,7 @@
           :key="item.title"
           :to="localePath({ name: item.route })"
           link
+          active-class="cyan--text text--accent-1"
         >
           <v-list-item-icon>
             <v-icon>{{ item.icon }}</v-icon>
@@ -53,7 +54,11 @@
           </v-list-item-content>
         </v-list-item>
 
-        <v-list-group :value="false" prepend-icon="mdi-web">
+        <v-list-group
+          :value="false"
+          prepend-icon="mdi-web"
+          active-class="cyan--text text--accent-1"
+        >
           <template v-slot:activator>
             <v-list-item-title>{{ $t("toolbar.languages") }}</v-list-item-title>
           </template>
@@ -63,6 +68,7 @@
             :key="locale.title"
             :to="switchLocalePath(locale.code)"
             link
+            active-class="cyan--text text--accent-1"
           >
             <v-list-item-content>
               <v-list-item-title>{{ locale.name }}</v-list-item-title>


### PR DESCRIPTION
## Resolves #150 

The active links are not visible. Using the `active-class` property, I changed their color to cyan, the primary color of the website. This property was changed for the links of the sidebar (both main links and languages), as well as the opened "Languages" tab. I checked the contrast with the Chrome developer tools and it respects the accessibility requirements.

### How to test
 
Open the sidebar to see color of the active links

### Screenshots
Before:
<img width="944" alt="Screenshot 2021-06-24 at 21 53 37" src="https://user-images.githubusercontent.com/39148794/123324038-a51ca400-d536-11eb-9cab-a429e242acb4.png">

After:
_Screenshots of the changes working_
<img width="1005" alt="Screenshot 2021-06-24 at 21 50 55" src="https://user-images.githubusercontent.com/39148794/123323772-48b98480-d536-11eb-8b85-bc47e2fa0472.png">

