### PR TITLE
Move login/logout to bottom of menu drawer (#167).

### DIFF
--- a/components/Toolbar.vue
+++ b/components/Toolbar.vue
@@ -78,7 +78,7 @@
       </v-list>
       <template v-slot:append>
         <div class="pa-2">
-          <v-btn :to="localePath(loginItem.route)" block dark>
+          <v-btn :to="localePath(loginItem.route)" block color="secondary">
             <v-icon color="white">
               {{ loginItem.icon }}
             </v-icon>

--- a/components/Toolbar.vue
+++ b/components/Toolbar.vue
@@ -76,6 +76,18 @@
           </v-list-item>
         </v-list-group>
       </v-list>
+      <template v-slot:append>
+        <div class="pa-2">
+          <v-btn :to="localePath(loginItem.route)" block dark>
+            <v-icon color="white">
+              {{ loginItem.icon }}
+            </v-icon>
+            <h5 class="white--text">
+              {{ loginItem.title }}
+            </h5>
+          </v-btn>
+        </div>
+      </template>
     </v-navigation-drawer>
   </div>
 </template>
@@ -90,37 +102,39 @@ export default {
   }),
   computed: {
     items() {
-      return [
+      let menuItems = [
         {
           title: this.$t("toolbar.home"),
           icon: "mdi-home-city",
           route: "index",
         },
-        this.$store.getters.isUserLoggedIn
-          ? [
-              {
-                title: this.$t("toolbar.adminDashboard"),
-                icon: "mdi-shield-account-variant",
-                route: "admin-pending",
-              },
-              {
-                title: this.$t("toolbar.logout"),
-                icon: "mdi-account",
-                route: "logout",
-              },
-            ]
-          : {
-              title: this.$t("toolbar.login"),
-              icon: "mdi-account",
-              route: "login",
-            },
         {
           title: this.$t("toolbar.about"),
           icon: "mdi-head-question",
           route: "about",
         },
-      ].flat();
+      ];
+      if (this.$store.getters.isUserLoggedIn) {
+        menuItems.push({
+          title: this.$t("toolbar.adminDashboard"),
+          icon: "mdi-shield-account-variant",
+          route: "admin-pending",
+        });
+      }
+      return menuItems.flat();
     },
+    loginItem: function() {
+      return this.$store.getters.isUserLoggedIn ?
+        {
+          title: this.$t("toolbar.logout"),
+          icon: "mdi-logout",
+          route: "logout",
+        } : {
+          title: this.$t("toolbar.login"),
+          icon: "mdi-account",
+          route: "login"
+        };
+    }
   },
   methods: {},
 };


### PR DESCRIPTION
## Resolves #167 

### How to test

1. `yarn dev`
2. Open drawer, confirm styling
3. Login, and confirm that this route functions
4. Open drawer, confirm styling
5. Logout, and confirm that this route functions


### Screenshots

<img width="400" alt="スクリーンショット 2021-06-25 20 01 22" src="https://user-images.githubusercontent.com/6155643/123415406-2a17c400-d5f0-11eb-8ce8-371d6b309a97.png">
<img width="384" alt="スクリーンショット 2021-06-25 20 02 10" src="https://user-images.githubusercontent.com/6155643/123415412-2e43e180-d5f0-11eb-9249-040cc9e0bba0.png">
