### PR TITLE
Localize disclaimer (#159)

### DIFF
--- a/components/Disclaimer.vue
+++ b/components/Disclaimer.vue
@@ -1,13 +1,6 @@
 <template>
   <div id="disclaimer">
-    The only vaccines approved in Japan are Moderna and Pfizer. Be wary of
-    clinics offering SinoVac or others. The content on this site is user
-    generated and while we do our best to moderate it, it may contain errors or
-    unverified content. <br /><br />
-    We are not liable for inaccurate information from these community
-    submissions, and we are not liable for third-party sites. Use your best
-    judgment and please use the report feature if you suspect fraudulent
-    information.
+    <p v-html="$t('message.disclaimerAlert')"></p>
   </div>
 </template>
 


### PR DESCRIPTION
## Part of #159 

### How to test

1. Site content should load as normal, with disclaimer visible
2. No HTML tags should be visible in disclaimer text
3. Changing to Japanese should show the correct message

### Screenshots
<img width="379" alt="スクリーンショット 2021-06-25 21 30 57" src="https://user-images.githubusercontent.com/6155643/123425003-841e8680-d5fc-11eb-9d03-347c1283ff71.png">
<img width="383" alt="スクリーンショット 2021-06-25 21 31 13" src="https://user-images.githubusercontent.com/6155643/123425014-87197700-d5fc-11eb-8031-5086ed45f140.png">

