### PR TITLE
Feature: increase clinics table header font size

### DIFF
--- a/components/CancellationList.vue
+++ b/components/CancellationList.vue
@@ -11,7 +11,7 @@
       :headers="headers"
       :items="items"
       :items-per-page="10"
-      class="elevation-2"
+      class="clinics-table elevation-2"
       :loading="loading"
       loading-text="Loading... Please wait"
       :search="search"
@@ -222,7 +222,7 @@ export default {
 };
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
 .v-sheet.v-card {
   padding-left: 20px !important;
   padding-right: 20px !important;
@@ -236,5 +236,11 @@ export default {
 }
 #waiting-lists-table {
   margin-bottom: 20px;
+}
+
+::v-deep .clinics-table {
+  table > thead > tr > th {
+    font-size: 1rem;
+  }
 }
 </style>

--- a/components/CancellationList.vue
+++ b/components/CancellationList.vue
@@ -240,7 +240,7 @@ export default {
 
 ::v-deep .clinics-table {
   table > thead > tr > th {
-    font-size: 1rem;
+    font-size: 0.875rem;
   }
 }
 </style>


### PR DESCRIPTION
## Resolves #18

I picked 0.875rem to override the 0.75rem as a test but I prefer leaving the choice to designers or lead as personally, the current font size is fine for me :stuck_out_tongue:

**Changes**

- Added SCSS support in `CancellationList.vue` styling to enjoy nesting
- Target clinics table with `.clinics-table` instead of `.v-data-table`, which could be possible due to scoped styling.
- Added the long chain `table > thead > tr > th` to have enough specify to override styling without `!important`

### How to test

- Checkout the branch
- Run the app

### Screenshots

![Screenshot from 2021-06-27 23-43-45](https://user-images.githubusercontent.com/40738601/123548871-971e8b80-d7a1-11eb-9676-24a3ee76532c.png)


