### PR TITLE
Feature: locale detection & persist user locale preference

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -127,6 +127,13 @@ export default {
       {
         locales: languages,
         defaultLocale: "en",
+        // https://i18n.nuxtjs.org/options-reference/#detectbrowserlanguage
+        detectBrowserLanguage: {
+          alwaysRedirect: true, // user selected locale takes precedence
+          fallbackLocale: "en",
+          onlyOnRoot: true, // recommended for SEO
+          useCookie: true,
+        },
         langDir: "i18n/locales",
         vueI18n: {
           fallbackLocale: "en",


### PR DESCRIPTION
## Resolves #133

Nuxt [browser language detection](https://i18n.nuxtjs.org/options-reference/#detectbrowserlanguage) also handle user language choice persistence so I prefer to have both features deployed together. Also, the changes are not that big so it is OK from my point of view

### How to test

How I tested (cf. attached video below)

Tests are done under Firefox. Private navigation is not required.

| Test                                      | Expectations / Results                                                      |
| ----------------------------------------- | --------------------------------------------------------------------------- |
| Set browser language to French.           | N/A                                                                         |
| Ensure cookies are cleared                | N/A                                                                         |
| Open localhost:3000                       | :heavy_check_mark: App opens in French \& Locale cookie value is now French |
| Open the language menu and select English | :heavy_check_mark: Locale cookie value is now English                       |
| Open a new tab and enter the URL again.   | :heavy_check_mark: App still opens in English \o/                           |
| Change Firefox language to Japanese.      | N/A                                                                         |
| Open localhost:3000                       | :heavy_check_mark: App opens in English because it was the saved locale     |
| Clear locale cookie                       | N/A                                                                         |
| Open localhost:3000                       | :heavy_check_mark: App opens in Japanese :tada:                             |

I haven't tested `fallbackLocale` by picking an exotic language as I consider our locale range being quite wide and also I trust the Nuxt folks :p 

:warning: Caveats

I am not sure if user will have a language option but if a device is shared by two users with different language preferences, this will need extra-work. However, considering findadoc use cases, I think that's a supeeer edge case :grin: 

### Screenshots


https://user-images.githubusercontent.com/40738601/123532557-1338b500-d749-11eb-8da5-25ab976dc5a3.mp4


