### PR TITLE
Feature: Workaround to use i18n in clinic form validations

### DIFF
--- a/pages/add-clinic.vue
+++ b/pages/add-clinic.vue
@@ -124,28 +124,60 @@ export default {
     prefectureList: json.prefectures,
     prefecture: "",
     city: "",
-    cityRules: [
-      (v) => !!v || "City is required",
-      (v) => (v && v.length >= 2) || "City name must be at least 2 characters",
-    ],
     ward: "",
-    wardRules: [
-      (v) => !!v || "Ward is required",
-      (v) => (v && v.length >= 2) || "Ward name must be at least 2 characters",
-    ],
     name: "",
-    nameRules: [
-      (v) => !!v || "Clinic name is required",
-      (v) =>
-        (v && v.length >= 2) || "Clinic name must be at least 2 characters",
-    ],
     note: "",
     website: "",
-    websiteRules: [
-      (v) => !!v || "Website URL is required",
-      (v) => (v && v.length >= 5) || "Please enter a valid URL",
-    ],
   }),
+
+  computed: {
+    cityRules() {
+      const minLength = 2;
+
+      return [
+        (v) => !!v || this.$i18n.t("add-clinic.validations.cityRequired"),
+        (v) =>
+          (v && v.length >= minLength) ||
+          this.$i18n.t("add-clinic.validations.cityValidation", [minLength]),
+      ];
+    },
+
+    wardRules() {
+      const minLength = 2;
+
+      return [
+        (v) => !!v || this.$i18n.t("add-clinic.validations.wardRequired"),
+        (v) =>
+          (v && v.length >= minLength) ||
+          this.$i18n.t("add-clinic.validations.wardValidation", [minLength]),
+      ];
+    },
+
+    nameRules() {
+      const minLength = 2;
+
+      return [
+        (v) => !!v || this.$i18n.t("add-clinic.validations.clinicRequired"),
+        (v) =>
+          (v && v.length >= minLength) ||
+          this.$i18n.t("add-clinic.validations.clinicValidation", [minLength]),
+      ];
+    },
+
+    websiteRules() {
+      // Simple URL pattern check: it must starts with either "http" or
+      // "https" and contains one character after the prefix.
+      // Regex can be tested on https://regex101.com/
+      const urlPattern = /^http[s]?:\/\/(.+)/g;
+
+      return [
+        (v) => !!v || this.$i18n.t("add-clinic.validations.websiteRequired"),
+        (v) =>
+          urlPattern.test(v) ||
+          this.$i18n.t("add-clinic.validations.websiteValidation"),
+      ];
+    },
+  },
 
   methods: {
     handleVoucherSwitch() {

--- a/pages/add-clinic.vue
+++ b/pages/add-clinic.vue
@@ -168,7 +168,7 @@ export default {
       // Simple URL pattern check: it must starts with either "http" or
       // "https" and contains one character after the prefix.
       // Regex can be tested on https://regex101.com/
-      const urlPattern = /^http[s]?:\/\/(.+)/g;
+      const urlPattern = /^http[s]?:\/\/(.+)/;
 
       return [
         (v) => !!v || this.$i18n.t("add-clinic.validations.websiteRequired"),

--- a/pages/add-clinic.vue
+++ b/pages/add-clinic.vue
@@ -135,10 +135,10 @@ export default {
       const minLength = 2;
 
       return [
-        (v) => !!v || this.$i18n.t("add-clinic.validations.cityRequired"),
+        (v) => !!v || this.$t("add-clinic.validations.cityRequired"),
         (v) =>
           (v && v.length >= minLength) ||
-          this.$i18n.t("add-clinic.validations.cityValidation", [minLength]),
+          this.$t("add-clinic.validations.cityValidation", [minLength]),
       ];
     },
 
@@ -146,10 +146,10 @@ export default {
       const minLength = 2;
 
       return [
-        (v) => !!v || this.$i18n.t("add-clinic.validations.wardRequired"),
+        (v) => !!v || this.$t("add-clinic.validations.wardRequired"),
         (v) =>
           (v && v.length >= minLength) ||
-          this.$i18n.t("add-clinic.validations.wardValidation", [minLength]),
+          this.$t("add-clinic.validations.wardValidation", [minLength]),
       ];
     },
 
@@ -157,10 +157,10 @@ export default {
       const minLength = 2;
 
       return [
-        (v) => !!v || this.$i18n.t("add-clinic.validations.clinicRequired"),
+        (v) => !!v || this.$t("add-clinic.validations.clinicRequired"),
         (v) =>
           (v && v.length >= minLength) ||
-          this.$i18n.t("add-clinic.validations.clinicValidation", [minLength]),
+          this.$t("add-clinic.validations.clinicValidation", [minLength]),
       ];
     },
 
@@ -171,10 +171,10 @@ export default {
       const urlPattern = /^http[s]?:\/\/(.+)/;
 
       return [
-        (v) => !!v || this.$i18n.t("add-clinic.validations.websiteRequired"),
+        (v) => !!v || this.$t("add-clinic.validations.websiteRequired"),
         (v) =>
           urlPattern.test(v) ||
-          this.$i18n.t("add-clinic.validations.websiteValidation"),
+          this.$t("add-clinic.validations.websiteValidation"),
       ];
     },
   },


### PR DESCRIPTION
## Resolves #31

I am not sure if this is the canonical way to do in Nuxt.js but it seems to work :grin: .  In a normal Vue.js application, `this.$t` is used in components and I haven't encountered data initialised with i18n entries (hence the idea to move the validation to computed property) and the i18n instance, created from `new Vuei18n(...)`,  is used in plain JavaScript / TypeScript files.

I also modify the check for website: instead of checking the website characters length, it must start with `http://` or `https://`:

![Screenshot from 2021-06-27 13-59-01](https://user-images.githubusercontent.com/40738601/123533365-e3d97680-d74f-11eb-973e-b9aa71a0736e.png)


### How to test

- Checkout branch + run the app
- Go the clinic add form
- Do mistakes

### Screenshots

![Screenshot from 2021-06-27 13-53-34](https://user-images.githubusercontent.com/40738601/123533321-526a0480-d74f-11eb-97a2-5aaadf24ad52.png)
![Screenshot from 2021-06-27 13-43-29](https://user-images.githubusercontent.com/40738601/123533325-539b3180-d74f-11eb-9a1c-78ad1613ffe6.png)

