### PR TITLE
Add i18n keys to contrib leads

### DIFF
--- a/components/ContributorsList.vue
+++ b/components/ContributorsList.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container>
     <v-row class="ma-2">
-      <h3>Project Leads</h3>
+      <h3>{{ $t("about.contributorLeads") }}</h3>
     </v-row>
     <v-row>
       <v-col sm="4" md="5" lg="6" v-for="lead in leads" :key="lead.name">

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -25,7 +25,7 @@
         {{ $t("about.supportA") }}
       </div>
       <div>
-        <h2>Who developed this site?</h2>
+        <h2>{{ $t("about.contributorQ") }}</h2>
         <contributors-list />
       </div>
     </div>


### PR DESCRIPTION
Adds translated strings to about this team section.

### How to test

1. Load about page
2. Change to JP, which has translations in place
(note that the subtitle "our team" is [awaiting merge of a fix from the i18n repo](https://github.com/ourjapanlife/findadoc-localization/pull/75), and is currently falling back to English)

### Screenshots

<img width="377" alt="スクリーンショット 2021-06-28 1 24 30" src="https://user-images.githubusercontent.com/6155643/123552070-70ffe800-d7af-11eb-9708-f11318456a9c.png">
