### PR TITLE
Add i18n for Shin Yokohama alert

### DIFF
--- a/components/AlertsList.vue
+++ b/components/AlertsList.vue
@@ -14,20 +14,10 @@
     </alert> -->
 
     <alert
-      button-text="Book Vaccine"
+      :button-text="$t('message.shinYokohamaBookVaccine')"
       button-url="https://mukogaoka.yamabiko-group.or.jp/index.html"
     >
-      <h2>URGENT!!</h2>
-      <br />
-      <b>Shin-Yokohama</b> vaccine slots available from <b>July 8th</b> that
-      will go to waste if not booked for immediately! If you live outside
-      Yokohama,
-      <a
-        href="https://v-sys.mhlw.go.jp/application/change-region.html"
-        target="_blank"
-        >click here to fill out and print the request form.</a
-      >
-      Then book the vaccine!
+      <p v-html="$t('message.shinYokohamaAlert')"></p>
     </alert>
   </v-container>
 </template>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1675,7 +1675,7 @@
 
 "@ourjapanlife/findadoc-localization@https://github.com/ourjapanlife/findadoc-localization":
   version "1.0.2"
-  resolved "https://github.com/ourjapanlife/findadoc-localization#6ef5c6817518c70ba69ed18f77f6cf3b27f4d4ff"
+  resolved "https://github.com/ourjapanlife/findadoc-localization#0686365178f7c40e6ed597e1dd09cdbc39174dbe"
 
 "@panva/asn1.js@^1.0.0":
   version "1.0.0"


### PR DESCRIPTION
Adds i18n text to urgent alert

### How to test

1. `yarn install; yarn dev`
2. Switch language to Japanese and check alert at the top of the page

### Screenshots

<img width="1234" alt="スクリーンショット 2021-07-08 16 06 18" src="https://user-images.githubusercontent.com/6155643/124877667-42cba500-e006-11eb-81f9-e24c7aca01ce.png">

