### PR TITLE
updating alert url to save clicks

### DIFF
--- a/components/AlertsList.vue
+++ b/components/AlertsList.vue
@@ -15,7 +15,7 @@
 
     <alert
       :button-text="$t('message.shinYokohamaBookVaccine')"
-      button-url="https://mukogaoka.yamabiko-group.or.jp/index.html"
+      button-url="https://yamabikovaccine.reserve.ne.jp/sp/index.php?"
     >
       <p v-html="$t('message.shinYokohamaAlert')"></p>
     </alert>


### PR DESCRIPTION
Updating the shin-yokohama alert url to save a few click getting to the appointment page. 