### PR TITLE
Move quotes behind other content in the tweet widget with z-index. 

### DIFF
--- a/components/TwitterTestimonials.vue
+++ b/components/TwitterTestimonials.vue
@@ -8,6 +8,7 @@
       v-model="activeTweetIndex"
       hide-delimiters
       :show-arrows="!$vuetify.breakpoint.mobile"
+      class="tweet-carousel"
       light
     >
       <v-carousel-item v-for="(tweet, i) in tweets" :key="tweet.id">
@@ -105,6 +106,7 @@ export default {
   height: 600px;
 }
 .quote-symbol {
+  z-index: 1;
   position: absolute;
   top: 24%;
   left: 33%;
@@ -115,5 +117,8 @@ export default {
 .tweet-widget .v-window__prev,
 .tweet-widget .v-window__next {
   background: inherit;
+}
+.tweet-carousel {
+  z-index: 2;
 }
 </style>


### PR DESCRIPTION
Fixes a minor display issue with the tweet widget.

## Resolves #240

### How to test

Check netlify preview for styles.

### Screenshots

<img width="609" alt="スクリーンショット 2021-07-17 10 22 48" src="https://user-images.githubusercontent.com/6155643/126021183-fa2cbaa2-c61d-4906-926a-bc91e4596021.png">
