### PR TITLE
Use translations for new about page

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,7 +28,16 @@ module.exports = {
     "vue/v-slot-style": 0,
     "vue/order-in-components": 0,
     "no-console": "error",
-    "@intlify/vue-i18n/no-raw-text": "error",
+    // Details here: https://eslint-plugin-vue-i18n.intlify.dev/rules/no-raw-text.html#rule-details
+    "@intlify/vue-i18n/no-raw-text": [
+    "error",
+      {
+        // Icons have literal text
+        "ignoreNodes": ["v-icon"],
+        // Ignore quotes and specific emoji used in design
+        "ignorePattern": "^[\"✋☕]"
+      }
+    ],
   },
   settings: {
     "vue-i18n": {

--- a/components/about/Header.vue
+++ b/components/about/Header.vue
@@ -2,7 +2,7 @@
   <div>
     <div class="header-widget">
       <div class="header-widget-content">
-        <h1>About Find A Doc, the database reducing vaccine waste.</h1>
+        <h1> {{ $t("about.header.headline") }} </h1>
       </div>
     </div>
     <AboutSvgWavyBump />

--- a/components/about/KofiWidget.vue
+++ b/components/about/KofiWidget.vue
@@ -5,17 +5,17 @@
         <v-col sm="12" class="kofi-widget-content-wrap">
           <div class="kofi-widget-content">
             <v-row>
-              <h2>Buy us coffee ☕</h2>
+              <h2>{{ $t("about.kofi.headline") }} ☕</h2>
             </v-row>
             <v-row>
-              <p>We are running this database after our 9-5 jobs. Help us stay awake!</p>
+              <p> {{ $t("about.kofi.text.0") }} </p>
             </v-row>
             <v-row>
-              <p>Consider supporting us if you find this project helped you or someone in your network.</p>
+              <p> {{ $t("about.kofi.text.1") }} </p>
             </v-row>
             <v-row>
               <v-btn link elevation="0" color="cyan" href="https://ko-fi.com/theyokohamalife">
-                Donate a cuppa
+                {{ $t("about.kofi.action") }}
               </v-btn>
             </v-row>
           </div>

--- a/components/about/SiteTimeline.vue
+++ b/components/about/SiteTimeline.vue
@@ -11,21 +11,23 @@
         <v-row>
             <v-col :cols="$vuetify.breakpoint.mobile ? 12 : 4">
               <h2>
-                {{ item.date }}
+                {{ $t(item.date) }}
               </h2>
               <div class="timeline-date-headline">
-                {{ item.dateHeadline }}
+                {{ $t(item.dateHeadline) }}
               </div>
             </v-col>
             <v-col :cols="$vuetify.breakpoint.mobile ? 12 : 7">
               <h3>
-                &quot; {{ item.textHeadline }} &quot;
+                &quot; {{ $t(item.textHeadline) }} &quot;
               </h3>
               <div>
-                <p v-html="item.text"></p>
+                <p v-for="text in item.text">
+                  {{ $t(text) }}
+                </p>
               </div>
               <div v-if="item.action">
-                <a :href="item.action.url">{{ item.action.title }}</a>
+                <a :href="item.action.url">{{ $t(item.action.title) }}</a>
               </div>
             </v-col>
         </v-row>
@@ -38,18 +40,24 @@ export default {
   data() {
     return {
       items: [{
-        date: "2021.06.17",
-        dateHeadline: "From idea to health database",
-        text: "On that day, LaShawn Toyoda had enough of the lack of direction from officials. A few hours later, Find a Doc is born.<br/> This database aims to better circulate the latest information on healthcare services in Japan.",
-        textHeadline: "Watch our daughter, I gotta make something.",
+        date: "about.timeline.items.0.date",
+        dateHeadline: "about.timeline.items.0.dateHeadline",
+        text: [
+          "about.timeline.items.0.text.0",
+          "about.timeline.items.0.text.1"
+        ],
+        textHeadline: "about.timeline.items.0.textHeadline",
       },
       {
-        date: "Presently",
-        dateHeadline: "A team of volunteers",
-        text: "Find a Doc is community-driven with the support of a team of volunteers. Currently, the team is focused on keeping the immigrant community informed about clinics offering waiting lists for vaccinations to reduce waste. <br> In the future, we want Find a Doc to help non-Japanese speaking residents of Japan find clinics that offer services in their native language.",
-        textHeadline: "You can fill the void by citizen action.",
+        date: "about.timeline.items.1.date",
+        dateHeadline: "about.timeline.items.1.dateHeadline",
+        text: [
+          "about.timeline.items.1.text.0",
+          "about.timeline.items.1.text.1"
+        ],
+        textHeadline: "about.timeline.items.1.textHeadline",
         action: {
-          title: "Check out &/or join the team",
+          title: "about.timeline.items.1.action",
           url: "https://github.com/ourjapanlife/findadoc-frontend"
         }
       }]
@@ -58,6 +66,11 @@ export default {
 };
 </script>
 <style>
+
+.v-timeline-item a {
+  text-decoration: underline !important; /* Because Vuetify forces this =( */
+}
+
 .timeline-widget h2, .timeline-widget h3 {
   font-family: "Montserrat";
 }

--- a/components/about/SiteTimeline.vue
+++ b/components/about/SiteTimeline.vue
@@ -22,7 +22,7 @@
                 &quot; {{ $t(item.textHeadline) }} &quot;
               </h3>
               <div>
-                <p v-for="text in item.text">
+                <p v-for="text in item.text" :key="text">
                   {{ $t(text) }}
                 </p>
               </div>

--- a/components/about/Team.vue
+++ b/components/about/Team.vue
@@ -4,7 +4,7 @@
     <div class="about-team-content">
       <v-container>
         <v-row>
-          <h2>Meet the Team</h2>
+          <h2> {{ $t("about.team.header.headline") }} </h2>
         </v-row>
         <v-row>
           <v-col cols="12" sm="12" md="6" lg="6" v-for="lead in teamLeads" :key="lead.name">
@@ -19,9 +19,20 @@
           <v-col sm="12" md="6" lg="6">
             <div class="about-team-more-contributors">
               <div>
-                <h3>Plus many more members who have lent us a helping hand!</h3>
+                <h3> {{ $t("about.team.moreContributors.headline") }} </h3>
                 <br />
-                <h3>Find them on our <a href="https://github.com/ourjapanlife/findadoc-frontend">front end</a> and <a href="https://github.com/ourjapanlife/findadoc-localization">localization</a> Github contributors pages</h3>
+                <i18n path="about.team.moreContributors.action.text" tag="h3">
+                  <template v-slot:frontend>
+                    <a href="https://github.com/ourjapanlife/findadoc-frontend">
+                      {{ $t('about.team.moreContributors.action.frontend') }}
+                    </a>
+                  </template>
+                  <template v-slot:localization>
+                    <a href="https://github.com/ourjapanlife/findadoc-localization">
+                      {{ $t('about.team.moreContributors.action.localization') }}
+                    </a>
+                  </template>
+                </i18n>
               </div>
             </div>
           </v-col>
@@ -29,9 +40,9 @@
         <v-row>
           <v-col sm="12">
             <div class="about-team-join">
-              <h3>Does Find a Doc’s mission spark your interests?</h3>
-              <h3>Join us over on GitHub to see how you can contribute!</h3>
-              <h3><a href="https://github.com/ourjapanlife">✋ I want to join!</a></h3>
+              <h3> {{ $t("about.team.join.headline") }} </h3>
+              <h3> {{ $t("about.team.join.subheadline") }} </h3>
+              <h3><a href="https://github.com/ourjapanlife">✋ {{ $t("about.team.join.action") }}</a></h3>
             </div>
           </v-col>
         </v-row>
@@ -93,7 +104,8 @@ export default {
   padding-bottom: 50px;
 }
 
-.mobile .about-team-more-contributors a, .mobile .about-team-join a {
+.about-team-more-contributors a, .about-team-join a,
+.mobile .about-team-more-contributors a, .mobile .about-team-join a  {
   text-decoration: underline !important; /* Required, as .v-application a is specified as no decoration */
 }
 

--- a/components/about/Trust.vue
+++ b/components/about/Trust.vue
@@ -4,8 +4,8 @@
         <v-row>
             <v-col col="12">
                 <div>
-                    <h3>Can this information be trusted?</h3>
-                    <h4>In short, yes, but do your due diligence</h4>
+                    <h3> {{ $t("about.trust.header.headline") }} </h3>
+                    <h4> {{ $t("about.trust.header.subheadline") }} </h4>
                 </div>
             </v-col>
         </v-row>
@@ -24,8 +24,8 @@
                 </v-avatar>
             </v-card-title>
             <v-card-text class="card-text">
-                <p>{{ card.text.line1 }}</p>
-                <p>{{ card.text.line2 }}</p>
+                <p>{{ $t(card.text.line1) }}</p>
+                <p>{{ $t(card.text.line2) }}</p>
             </v-card-text>
           </v-card>
         </v-col>
@@ -33,11 +33,11 @@
       <v-row>
         <v-col col="12">
             <h5>
-                This is an open-source project, and we are not liable for any damages that may be incurred from the use of Find a Doc.
+                {{ $t("about.trust.footer.headline") }}
             </h5>
             <h6>
                 <a href="https://github.com/ourjapanlife/findadoc-frontend/blob/main/LICENSE">
-                    Read more about it in our license.
+                    {{ $t("about.trust.footer.license") }}
                 </a>
             </h6>
         </v-col>
@@ -53,22 +53,22 @@ export default {
       {
         avatar: "AboutSvgDocumentsIcon",
         text: {
-            line1: "All links lead to official resources such as clinic and government websites.",
-            line2: "Read them thoroughly before registering your personal information with them."
+            line1: "about.trust.cards.0.text.0",
+            line2: "about.trust.cards.0.text.1"
         }
       },
       {
         avatar: "AboutSvgDiversityIcon",
         text: {
-            line1: "Anyone in the community can submit content to the database.",
-            line2: "As a result, is not possible for us to guarantee that accuracy. If you notice any errors, please report the issue to moderators."
+            line1: "about.trust.cards.1.text.0",
+            line2: "about.trust.cards.1.text.1"
         }
       },
       {
         avatar: "AboutSvgSearchIcon",
         text: {
-            line1: "Our moderators try their best to detect fraudulent information.",
-            line2: "Even so, research any service that you find on here before visiting the location or submitting your personal information to a third-party website."
+            line1: "about.trust.cards.2.text.0",
+            line2: "about.trust.cards.2.text.1"
         }
       }
       ]

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -25,10 +25,11 @@ export default {
 </style>
 
 <style>
-html, body {
+html,
+body {
   overflow-x: hidden;
 }
 body {
-  position: relative
+  position: relative;
 }
 </style>

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@nuxtjs/axios": "^5.13.6",
     "@nuxtjs/firebase": "^7.6.1",
     "@nuxtjs/proxy": "^2.1.0",
-    "@ourjapanlife/findadoc-localization": "https://github.com/ourjapanlife/findadoc-localization#v1.0.7",
+    "@ourjapanlife/findadoc-localization": "https://github.com/ourjapanlife/findadoc-localization#v1.0.8",
     "core-js": "^3.9.1",
     "firebase": "^8.6.7",
     "nuxt": "^2.15.3",

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -45,8 +45,8 @@ export default {
     const tweets = await twitter.getTweets();
 
     return {
-      tweets: tweets
-    }
+      tweets: tweets,
+    };
   },
 };
 </script>

--- a/services/twitter.js
+++ b/services/twitter.js
@@ -9,7 +9,6 @@ const API_URL =
 const DEV_MODE = "DEV_MODE";
 
 class TwitterService {
-
   constructor(axios) {
     this.axios = axios;
   }
@@ -40,7 +39,7 @@ class TwitterService {
     }
 
     if (!this._isValidResponse(json)) {
-      logger.log("Invalid response from Twitter API, loading fixtures.")
+      logger.log("Invalid response from Twitter API, loading fixtures.");
       json = tweetFixtures;
     }
 
@@ -91,6 +90,6 @@ class TwitterService {
 
     return annotatedTweets;
   }
-};
+}
 
 export default TwitterService;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1809,9 +1809,9 @@
     mustache "^2.3.0"
     stack-trace "0.0.10"
 
-"@ourjapanlife/findadoc-localization@https://github.com/ourjapanlife/findadoc-localization#v1.0.6":
-  version "1.0.6"
-  resolved "https://github.com/ourjapanlife/findadoc-localization#2f534bef20905ed29511e551693a85487f1a40dc"
+"@ourjapanlife/findadoc-localization@https://github.com/ourjapanlife/findadoc-localization#v1.0.8":
+  version "1.0.8"
+  resolved "https://github.com/ourjapanlife/findadoc-localization#9a0b09ffc06b6431cf096d5806405aafd102034e"
 
 "@panva/asn1.js@^1.0.0":
   version "1.0.0"


### PR DESCRIPTION
Adds translations to the new about page added in #251 

### How to test

Use netlify preview or pull down and `yarn install`. Page should look EXACTLY like prod.
