### PR TITLE
fixed about page build error

### DIFF
--- a/services/twitter.js
+++ b/services/twitter.js
@@ -39,7 +39,7 @@ class TwitterService {
     }
 
     if (!this._isValidResponse(json)) {
-      logger.log("Invalid response from Twitter API, loading fixtures.");
+      logger.warn("Invalid response from Twitter API, loading fixtures.");
       json = tweetFixtures;
     }
 


### PR DESCRIPTION
## Resolves #265

Fixed the about page building error bug. `logger.log()` was being called, but this function doesn't exist. 

### How to test

When you run the generate command (or see the netllify build logs, the error should no longer exist. 
