### PR TITLE
Update readme: node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,13 @@ Make sure you have node [`v16.4.2`](.nvmrc) installed before installing the depe
 
 If you don't have it, the easiest way to manage node versions is by using nvm. Read the [`Install NVM guide`](https://github.com/nvm-sh/nvm#installing-and-updating).
 
-After installing it, just run
+After installing it, you need to install the correct node version:
+
+```bash
+nvm install 16.4.2
+```
+
+After the installation, just use it:
 
 ```bash
 nvm use

--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ If you have more issues with submodules, please check out [the wiki troubleshoot
 
 ## Getting started / Running the app
 
+Make sure you have node [`v16.4.2`](.nvmrc) installed before installing the dependencies.
+
+If you don't have it, the easiest way to manage node versions is by using nvm. Read the [`Install NVM guide`](https://github.com/nvm-sh/nvm#installing-and-updating).
+
+After installing it, just run
+
+```bash
+nvm use
+```
+
+Now you're ready to install the dependencies and run the app.
+
 ```bash
 # install dependencies
 $ yarn


### PR DESCRIPTION
## Description

When running with a different node version from this project, I always get this error in the terminal.

```bash
The engine "node" is incompatible with this module. Expected version "^12.22.0 || ^14.17.0 || >=16.0.0". Got "12.16.2"
```

I updated the readme to make sure the correct node version is installed and used with nvm.