### PR TITLE
Update readme to improved DX

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,29 @@ If you have more issues with submodules, please check out [the wiki troubleshoot
 
 ## Getting started / Running the app
 
+Install dependencies
+
 ```bash
-# install dependencies
-$ yarn
+yarn
+```
 
-# serve with hot reload at localhost:3000
-$ yarn dev
+Serve with hot reload at localhost:3000
 
-# build for production and launch server
-$ yarn build
-$ yarn start
+```bash
+yarn dev
+```
 
-# generate static project
-$ yarn generate
+Build for production and launch server
+
+```bash
+yarn build
+yarn start
+```
+
+Generate static project
+
+```bash
+yarn generate
 ```
 
 **NOTE**: To see current environment you are connected to, check the console logs.
@@ -46,3 +56,7 @@ The locale files are managed through [the localization repo](https://github.com/
 5. Update the package inside `package.json` using `yarn upgrade @ourjapanlife/findadoc-localization` to get the latest keys imported
 6. Run `yarn` again
 7. Make your change in this repo with the new i18n keys and submit your PR 🎉
+
+```
+
+```


### PR DESCRIPTION
## Description

Update readme to improved developer experience. Before, we needed to select the text and `cmd+c`/`ctrl+c`. With every step separate and without the `$`, we can just click to copy to the clipboard.

### Screenshots

![clipboard-findadoc](https://user-images.githubusercontent.com/5835798/135007699-684fb814-3c85-4794-bcff-eb00303f1dc3.gif)

A live example: https://github.com/leandrotk/findadoc-frontend/blob/f3a6bd3049881a09f78da8a5a86118501f0b6f6a/README.md