### PR TITLE
Improvements for read more and find a doc buttons

### DIFF
--- a/components/HeroSection.vue
+++ b/components/HeroSection.vue
@@ -42,7 +42,7 @@
           :class="
             $vuetify.breakpoint.mobile
               ? 'text-h4 font-weight-bold pt-0'
-              : 'text-h1 font-weight-bold pt-0'
+              : 'text-h2 font-weight-bold pt-0'
           "
         >
           {{ $t("hero.getVaccinated") }}
@@ -61,11 +61,9 @@
           >
             <v-card-actions>
               <a href="#waiting-lists-table">
-                <v-btn
-                  color="secondary"
-                  class="custom-transform-class text-none ml-3"
-                  >{{ $t("findADoc") }}</v-btn
-                >
+                <v-btn color="secondary" class="custom-transform-class ml-3">{{
+                  $t("findADoc")
+                }}</v-btn>
               </a>
             </v-card-actions>
           </v-img>
@@ -73,11 +71,9 @@
         <div v-else>
           <v-card-actions>
             <a href="#waiting-lists-table">
-              <v-btn
-                color="secondary"
-                class="custom-transform-class text-none ml-3"
-                >{{ $t("findADoc") }}</v-btn
-              >
+              <v-btn color="secondary" class="custom-transform-class ml-3">{{
+                $t("findADoc")
+              }}</v-btn>
             </a>
           </v-card-actions>
         </div>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -25,10 +25,10 @@
             })
           "
         >
-          <v-btn text color="teal accent-4"
-            >{{ $t("general.readMore") }}
-          </v-btn></NuxtLink
-        >
+          <v-btn text color="secondary accent-4">
+            {{ $t("general.readMore") }}
+          </v-btn>
+        </NuxtLink>
       </v-card-subtitle>
       <v-divider></v-divider>
     </v-card>


### PR DESCRIPTION
## Resolves #252

- find a doc button uppercased
- read more with accessible color
- made title smaller for desktop version following [figma design](https://www.figma.com/proto/kdgcV9gd3cOeiSgoXY6VLM/Find-a-Doc?node-id=302%3A272&scaling=min-zoom&page-id=167%3A83&starting-point-node-id=302%3A272&hotspot-hints=0&hide-ui=1)

### How to test

- Open website (locally or preview)
- Check the new title size
- Check the uppercased button `FIND A DOC`
- Check the `READ MORE` button's new color

### Screenshots

#### Before

![Screenshot from 2021-10-05 14-57-49](https://user-images.githubusercontent.com/5835798/136077736-84c41329-dd0b-4b2a-a9dc-59809f1aaaa4.png)

#### After

![Screenshot from 2021-10-05 14-58-07](https://user-images.githubusercontent.com/5835798/136077738-db8f92e4-0cef-4720-a94e-224b67410da5.png)
