### PR TITLE
Wrap hero card title in h1 tag

### DIFF
--- a/components/HeroSection.vue
+++ b/components/HeroSection.vue
@@ -38,12 +38,12 @@
             </v-row>
           </template>
         </v-img>
-        <v-card-title>
+        <v-card-title class="pt-0">
           <h1
             :class="
               $vuetify.breakpoint.mobile
-                ? 'text-h4 font-weight-bold pt-0'
-                : 'text-h1 font-weight-bold pt-0'
+                ? 'text-h4 font-weight-bold'
+                : 'text-h1 font-weight-bold'
             "
           >
             {{ $t("hero.getVaccinated") }}


### PR DESCRIPTION
## Resolves #289 

### How to test

Inspect the page title on the homepage and confirm that it is wrapped by a h1 tag and the layout remains unaffected. Scanning the page using the axe Dev Tools should show that the moderate error _Page should contain a level-one heading_ has been resolved.

### Screenshots

| Before | After |
| --------- | ------ |
| ![axe before](https://user-images.githubusercontent.com/28100/136782128-20e94d00-dfdb-4c7b-92da-55ae564d04ce.png) | ![axe after](https://user-images.githubusercontent.com/28100/136782155-d6e87cef-91d8-46c7-95bd-e7affc691b1a.png) |
| ![home before](https://user-images.githubusercontent.com/28100/136782194-8a6c9f24-15b2-4570-82b1-9fb74f08d8c5.png) |![home after](https://user-images.githubusercontent.com/28100/136782223-bc9f6a10-9da7-4220-a7ff-07ba84465158.png)|


