### PR TITLE
eslint - fix closing brackets going to next line.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,13 @@ module.exports = {
     "vue/attributes-order": 0,
     "vue/v-slot-style": 0,
     "vue/order-in-components": 0,
+    "vue/html-closing-bracket-newline": [
+      "error",
+      {
+        singleline: "never",
+        multiline: "never",
+      },
+    ],
     "no-console": "error",
     // Details here: https://eslint-plugin-vue-i18n.intlify.dev/rules/no-raw-text.html#rule-details
     "@intlify/vue-i18n/no-raw-text": [


### PR DESCRIPTION
## What's in this PR?

- [x] Updating one eslint rule. Brackets we're being carried to the next line which made things difficult to read in longer html tags with attributes. 

Old Example
![image](https://user-images.githubusercontent.com/4411499/139587530-5d54dc36-d2b5-402a-9053-08ca732ef1b4.png)
